### PR TITLE
adding to .brew/opt path, updating garageband instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,8 @@ Make an issue if you encounter any problems!
 
 # Free Up Space
 If you don't use GarageBand, please follow these steps first.
-* Open the Apple menu in the top left.
-* Click "About This Mac"
-* Click the "Storage" button
-* Click "Manage Storage"
-* Click "Music Creation" on the left side
-* Press the removal button in the middle and confirm it. This will free up 20GB of storage on your computer.
+* Open "APS Self Service" (You can get to this from Launchpad)
+* Search for and run a program with a name called something like "Uninstall GarageBand"
 
 # Common Installation Steps
 Right-click and click "Save as..." on [this link.](https://raw.githubusercontent.com/ModdedGamers/brew-easy-install/main/brew-easy-install.sh)

--- a/brew-easy-install.sh
+++ b/brew-easy-install.sh
@@ -10,7 +10,16 @@
 export DIR="${HOME}/.brew"
 ## Set URL for brew download
 export URL="https://github.com/Homebrew/brew/tarball/master"
-export RC_SETUP="brew_init () { eval \$(\$HOME/.brew/bin/brew shellenv) }\nbrew_init\nexport HOMEBREW_NO_ANALYTICS=1\nexport HOMEBREW_INSTALL_FROM_API=1\nalias brew_cleanup=\"brew cleanup -s\"\nHOMEBREW_CASK_OPTS=\"--appdir=~/Applications\"\nHOMEBREW_INSTALL_BADGE=\"🐧\"\nexport PATH=\"\$HOME/.brew/bin:\$HOME/.brew/sbin:\$HOME/.brew/opt/*/bin:\$HOME/.brew/opt/*/sbin:\$PATH\""
+
+export RC_SETUP="
+  brew_init () { eval \$(\$HOME/.brew/bin/brew shellenv) }
+  brew_init
+  export HOMEBREW_NO_ANALYTICS=1
+  alias brew_cleanup=\"brew cleanup -s\"
+  HOMEBREW_CASK_OPTS=\"--appdir=~/Applications\"
+  HOMEBREW_INSTALL_BADGE=\"🐧\"
+  export PATH=\"\$HOME/.brew/bin:\$HOME/.brew/sbin:\$HOME/.brew/opt/*/bin:\$HOME/.brew/opt/*/sbin:\$PATH\"
+"
 
 ## Don't let brew send analytics during install.
 export HOMEBREW_NO_ANALYTICS_THIS_RUN=1
@@ -37,7 +46,7 @@ for file in ${RCFILES[@]} ;do echo "${RC_SETUP}" >> "$HOME/$file"; done
 printf "\nDisclaimers:\n\n"
 printf "Since this uses a non-standard prefix, most things will be built\n"
 printf "from source.\n\n "
-printf "Things may take a while. Please yell at APS to let us install brew\n\n"
+printf "Things may take a while. Please yell at APS to let us install brew normally\n\n"
 printf "Aaron Rabach is not responsible for any stupid things that you \n"
 printf "\"brew install\". Thanks!\n\n"
 printf "Done!"

--- a/brew-easy-install.sh
+++ b/brew-easy-install.sh
@@ -10,7 +10,8 @@
 export DIR="${HOME}/.brew"
 ## Set URL for brew download
 export URL="https://github.com/Homebrew/brew/tarball/master"
-export RC_SETUP="brew_init () { eval \$(\$HOME/.brew/bin/brew shellenv) }\nbrew_init\nexport HOMEBREW_NO_ANALYTICS=1\nexport HOMEBREW_INSTALL_FROM_API=1\nalias brew_cleanup=\"brew cleanup -s\"\nHOMEBREW_CASK_OPTS=\"--appdir=~/Applications\"\nHOMEBREW_INSTALL_BADGE=\"🐧\""
+export RC_SETUP="brew_init () { eval \$(\$HOME/.brew/bin/brew shellenv) }\nbrew_init\nexport HOMEBREW_NO_ANALYTICS=1\nexport HOMEBREW_INSTALL_FROM_API=1\nalias brew_cleanup=\"brew cleanup -s\"\nHOMEBREW_CASK_OPTS=\"--appdir=~/Applications\"\nHOMEBREW_INSTALL_BADGE=\"🐧\"\nexport PATH=\"\$HOME/.brew/bin:\$HOME/.brew/sbin:\$HOME/.brew/opt/*/bin:\$HOME/.brew/opt/*/sbin:\$PATH\""
+
 ## Don't let brew send analytics during install.
 export HOMEBREW_NO_ANALYTICS_THIS_RUN=1
 ## Don't let homebrew tell us about analytics, as we'll disable them later anyways


### PR DESCRIPTION
Hi - thanks for making this repo! I'm a new CS teacher at ACC, and this script is still our go-to for installing code that we need on student macbooks.

There are just two changes that we need to keep this working: first, the method for uninstalling GarageBand has changed.

Second - when students use brew to install programs (like libpq), they aren't automatically appearing in their PATH. I think this change to the *rc files should add the correct folder (.brew/opt, where is where brew symlinks installed programs).

I think this change relates to the fact that brew's install path is different for Apple Silicon computers. See: https://brew.sh/2021/02/05/homebrew-3.0.0/

I'm not positive that this will fix everything, but I think it's better. I'd be happy to hear any feedback!